### PR TITLE
Add `AuthGuard` middleware

### DIFF
--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -30,13 +30,8 @@ export default class AuthController {
     return res.json({ token: authToken }, 200);
   }
 
-  static async disConnect(req, res) {
-    const token = req.headers['x-token'];
-    const userId = await redisClient.get(`auth_${token}`);
-
-    if (!userId) {
-      return res.json({ error: 'Unauthorized' }, 401);
-    }
+  static async getDisconnect(req, res) {
+    const { token } = req;
 
     redisClient.del(`auth_${token}`);
 

--- a/controllers/UsersController.js
+++ b/controllers/UsersController.js
@@ -39,18 +39,8 @@ class UsersController {
   }
 
   static async getMe(req, res) {
-    const token = req.headers['x-token'];
-    const userId = await redisClient.get(`auth_${token}`);
-
-    if (!userId) {
-      return res.json({ error: 'Unauthorized' }, 401);
-    }
-
-    const user = await dbClient.users.findOne({ _id: new ObjectId(userId) });
-
-    console.log(user);
-
-    return res.json({ id: user._id, email: user.email });
+    const { userId, user } = req;
+    return res.json({ id: userId, email: user.email });
   }
 }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -17,6 +17,6 @@ router.get('/users/me', AuthGuard, UsersController.getMe);
 
 // auth
 router.get('/connect', AuthController.getConnect);
-router.get('/disconnect', AuthController.getDisconnect);
+router.get('/disconnect', AuthGuard, AuthController.getDisconnect);
 
 export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,8 @@ import AppController from '../controllers/AppController';
 import UsersController from '../controllers/UsersController';
 import AuthController from '../controllers/AuthController';
 
+import { AuthGuard } from '../utils/middlewares';
+
 const router = Router();
 
 // check stats and status
@@ -11,10 +13,10 @@ router.get('/stats', AppController.getStats);
 
 // users
 router.post('/users', UsersController.postNew);
-router.get('/users/me', UsersController.getMe);
+router.get('/users/me', AuthGuard, UsersController.getMe);
 
 // auth
 router.get('/connect', AuthController.getConnect);
-router.get('/disconnect', AuthController.disConnect);
+router.get('/disconnect', AuthController.getDisconnect);
 
 export default router;


### PR DESCRIPTION
- Add a new middleware `AuthGuard`, that protects a route with user authentication.
    > But why? this will prevent repeating the user auth checking code through different routes, just use the `AuthGuard` middleware as the following:
    ```ts
        router.get('/some-endpoint-to-protect', AuthGuard, ...controllerFunction);
    ```
    - If authentication failed, the middleware will respond with `Unauthorized` error message with `401` status code.
    - If authentication passes, it will provide the following variables to the controller:
        - **req.user**: The user object
        - **req.userId**: The user id.
        - **req.token**: The provided token.
- Update the routes `GET /disconnect` and `GET /users/me` and their control functions to use the `AuthGuard` middleware.