### PR TITLE
fix: `GET /files/:id/data` endpoint

### DIFF
--- a/controllers/FilesController.js
+++ b/controllers/FilesController.js
@@ -129,7 +129,7 @@ export default class FilesController {
     // make sure the user account exists
     const user = await dbClient.users.findOne({ _id: new ObjectId(userId) });
     if (!user) {
-      return res.sendError('Not found', 401);
+      return res.sendError('Not found', 404);
     }
 
     const file = await dbClient.files.findOne({


### PR DESCRIPTION
If user not found returns `401` while it should be `404`.
Should fix some checks of task 8.